### PR TITLE
hammerspoon: launch apps after modifiers release

### DIFF
--- a/.hammerspoon/init.lua
+++ b/.hammerspoon/init.lua
@@ -27,8 +27,29 @@ local apps = {
 local lastApp = nil
 local previousAppByKey = {}
 
+local function areStartupModifiersReleased()
+	local modifiers = hs.eventtap.checkKeyboardModifiers()
+
+	return not modifiers.ctrl and not modifiers.alt and not modifiers.cmd and not modifiers.shift
+end
+
+local function afterStartupModifiersReleased(fn)
+	if areStartupModifiersReleased() then
+		fn()
+		return
+	end
+
+	local timer = nil
+	timer = hs.timer.doEvery(0.02, function()
+		if areStartupModifiersReleased() then
+			timer:stop()
+			fn()
+		end
+	end)
+end
+
 local function bindAppLauncher(key, app)
-	hs.hotkey.bind(hyper, key, function()
+	local function launchOrToggleApp()
 		local frontmost = hs.application.frontmostApplication()
 
 		if frontmost and frontmost:bundleID() == app.bundleID then
@@ -47,6 +68,12 @@ local function bindAppLauncher(key, app)
 		end
 
 		hs.application.launchOrFocusByBundleID(app.bundleID)
+	end
+
+	-- Delay app launch/focus until startup modifiers are released so apps do
+	-- not see held Shift/Option/Command/Control during launch.
+	hs.hotkey.bind(hyper, key, function() end, function()
+		afterStartupModifiersReleased(launchOrToggleApp)
 	end)
 end
 


### PR DESCRIPTION
## Summary
- keep the existing Caps Lock Hyper chord as Control+Option+Command+Shift
- run app launcher actions after startup modifiers are released
- preserve app toggle behavior while preventing held modifiers from leaking into launched apps

## Why
Holding the Hyper chord while launching apps can leak startup modifiers into the target app. That matters for apps like Music and Photos, where macOS documents modifier-driven startup behavior. This PR was the first attempt to stop that leakage.

## Tradeoff
This approach waits for the physical modifiers to be released before launching or focusing the app, so it avoids the modifier leak but adds perceived latency. PR #5 supersedes this with an immediate approach.

## Test
- luac -p .hammerspoon/init.lua