### PR TITLE
hammerspoon: mask modifiers before launching apps

### DIFF
--- a/.hammerspoon/init.lua
+++ b/.hammerspoon/init.lua
@@ -26,9 +26,22 @@ local apps = {
 -- not via a hotkey).
 local lastApp = nil
 local previousAppByKey = {}
+local startupModifiers = { "ctrl", "alt", "cmd", "shift" }
+
+local function releaseStartupModifiers()
+	local modifiers = hs.eventtap.checkKeyboardModifiers()
+
+	for _, modifier in ipairs(startupModifiers) do
+		if modifiers[modifier] then
+			hs.eventtap.event.newKeyEvent({}, modifier, false):post()
+		end
+	end
+end
 
 local function bindAppLauncher(key, app)
 	hs.hotkey.bind(hyper, key, function()
+		releaseStartupModifiers()
+
 		local frontmost = hs.application.frontmostApplication()
 
 		if frontmost and frontmost:bundleID() == app.bundleID then


### PR DESCRIPTION
## Summary
- keep the existing Caps Lock Hyper chord as Control+Option+Command+Shift
- post synthetic key-up events for held startup modifiers before launching/focusing apps
- preserve immediate key-down app launching without the latency from waiting for physical key release

## Notes
This supersedes #4. PR #4 avoids startup modifier leakage by waiting until the physical modifiers are released, but that adds perceived launch latency. This PR masks the modifiers immediately instead.

## Test
- luac -p .hammerspoon/init.lua